### PR TITLE
Fix Cloudflare Pages deployment by upgrading Wrangler to v3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,21 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: 12
+        node-version: 20
     - run: yarn install
     - run: yarn build
       env:
         NODE_ENV: production
     - name: Publish
-      uses: cloudflare/wrangler-action@1.3.0
+      uses: cloudflare/wrangler-action@3
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
         preCommands: |
-          wrangler kv:namespace create KV_STATUS_PAGE || true
-          export KV_NAMESPACE_ID=$(npx @cloudflare/wrangler@1 kv:namespace list 2> >(tee stderr.log >&2) | head -1 | node -pe "JSON.parse(fs.readFileSync('/dev/stdin').toString()).find(kv => kv.title.includes('KV_STATUS_PAGE')).id")
+          npx wrangler kv namespace create KV_STATUS_PAGE || true
+          export KV_NAMESPACE_ID=$(npx wrangler kv namespace list 2> >(tee stderr.log >&2) | head -1 | node -pe "JSON.parse(fs.readFileSync('/dev/stdin').toString()).find(kv => kv.title.includes('KV_STATUS_PAGE')).id")
           echo "[env.production]" >> wrangler.toml
           echo "kv_namespaces = [{binding=\"KV_STATUS_PAGE\", id=\"${KV_NAMESPACE_ID}\"}]" >> wrangler.toml
           [ -z "$SECRET_SLACK_WEBHOOK_URL" ] && echo "Secret SECRET_SLACK_WEBHOOK_URL not set, creating dummy one..." && SECRET_SLACK_WEBHOOK_URL="default-gh-action-secret" || true

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "flareact dev",
     "build": "yarn css && flareact build",
-    "deploy": "yarn build && flareact publish",
+    "deploy": "yarn build && npx wrangler deploy",
     "kv-gc": "node ./src/cli/gcMonitors.js",
     "format": "prettier --write '**/*.{js,css,json,md}'",
     "css": "postcss public/tailwind.css -o public/style.css"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,16 +1,17 @@
 name = "cf-workers-status-page"
 workers_dev = true
 account_id = ""
-type = "webpack"
-webpack_config = "node_modules/flareact/webpack"
 compatibility_date = "2021-07-23"
+main = "dist/main.js"
+
+[build]
+command = "NODE_OPTIONS=--openssl-legacy-provider npx webpack --config node_modules/flareact/configs/webpack.worker.config.js --mode production"
 
 [triggers]
 crons = ["*/5 * * * *"]
 
 [site]
 bucket = "out"
-entry-point = "./"
 
 # uncomment and adjust following if you are not using GitHub Actions
 #[env.production]


### PR DESCRIPTION
Wrangler v1 GitHub Actions have started throwing errors since the old Rust CLI has been fully retired and the endpoints have changed. Upgraded `cloudflare/wrangler-action` to v3 and upgraded Node in CI to v20, migrated `wrangler.toml` off the deprecated `type="webpack"` to a custom builder script, and updated the preCommands in the workflow to match `wrangler` v3 syntax.

---
*PR created automatically by Jules for task [14953179870394112942](https://jules.google.com/task/14953179870394112942) started by @pniedzwiedzinski*