### PR TITLE
Fix deployment by upgrading to Wrangler v3\n\n- Update Cloudflare Wra…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,11 @@ jobs:
       uses: cloudflare/wrangler-action@v3
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
+        accountId: ${{ secrets.CF_ACCOUNT_ID }}
         preCommands: |
           npx wrangler kv namespace create KV_STATUS_PAGE || true
-          export KV_NAMESPACE_ID=$(npx wrangler kv namespace list 2> >(tee stderr.log >&2) | head -1 | node -pe "JSON.parse(fs.readFileSync('/dev/stdin').toString()).find(kv => kv.title.includes('KV_STATUS_PAGE')).id")
+          npx wrangler kv namespace list > kv_namespaces.json 2> stderr.log
+          export KV_NAMESPACE_ID=$(node -pe "JSON.parse(fs.readFileSync('kv_namespaces.json').toString()).find(kv => kv.title.includes('KV_STATUS_PAGE')).id")
           echo "[env.production]" >> wrangler.toml
           echo "kv_namespaces = [{binding=\"KV_STATUS_PAGE\", id=\"${KV_NAMESPACE_ID}\"}]" >> wrangler.toml
           [ -z "$SECRET_SLACK_WEBHOOK_URL" ] && echo "Secret SECRET_SLACK_WEBHOOK_URL not set, creating dummy one..." && SECRET_SLACK_WEBHOOK_URL="default-gh-action-secret" || true


### PR DESCRIPTION
…ngler GitHub Action from v1.3.0 to v3\n- Drop use of deprecated `type="webpack"` in `wrangler.toml` in favor of a custom build script.\n- Update Node.js to v20 in `deploy.yml` to support Wrangler v3.\n- Update KV commands inside GitHub actions preCommands to be compatible with `wrangler` v3 and avoid /bin/sh syntax errors.\n- Inject explicit Cloudflare account ID to avoid requiring /memberships read scope.